### PR TITLE
Support default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .DS_Store
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Support default values
+
 ## [1.0.7][] - 2023-04-29
 
 - Drop node.js 14 support, add node.js 20

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ const templ = t`${'hello'} ${'myFriend'}, great ${'positions'} of Rome`;
 console.log(templ(data));
 ```
 
+With default values provided (optionally):
+
+```js
+const t = require('tickplate');
+
+const data = {
+  greeting: 'Valē!',
+  person: {
+    name: 'Lucius Aurelius Verus',
+    toString() {
+      return this.name;
+    },
+  },
+  positions: ['brother', 'emperor', 'co-emperor'],
+  ruleFrom: 161,
+  ruleTo: 169,
+};
+
+const templ = t`${'greeting='} ${'person="Marcus Aurelius"'}, great ${'positions=["emperor", "philosopher"]'} of Rome from ${'ruleFrom=161'} to ${'ruleTo=180'} AD`;
+
+console.log(templ(data));
+```
+
 ## License & Contributors
 
 Copyright (c) 2017-2023 [Metarhia contributors](https://github.com/metarhia/tickplate/graphs/contributors).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tickplate",
       "version": "1.0.7",
       "license": "MIT",
+      "dependencies": {
+        "metautil": "^3.15.0"
+      },
       "devDependencies": {
         "eslint": "^8.34.0",
         "eslint-config-metarhia": "^8.1.0",
@@ -1908,6 +1911,18 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/metautil": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/metautil/-/metautil-3.15.0.tgz",
+      "integrity": "sha512-kGG920X8R10X6He2VKPRQFtG45DcDCSYgZehUFoqES52Tv88VALJm6EplZGwDRK7IiBDWsWDeS8d2OcW6bVXeg==",
+      "engines": {
+        "node": "18 || 20"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/tshemsedinov"
       }
     },
     "node_modules/micromatch": {

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "metautil": "^3.15.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -65,4 +65,22 @@ const t = require('./tickplate.js');
     templ({ greeting: 'Valē!!!', ruleFrom: '44 BC', ruleTo: 2023 }),
     'Valē!!! Marcus Aurelius, great emperor,philosopher of Rome from 44 BC to 2023 AD',
   );
+
+  const messedUp = t`${'greeting= /\\/'} ${'person = " "'}, great ${'positions  ="emperor", "philosopher"]]'} of Rome from ${'ruleFrom    = undefined'} to ${'ruleTo==180'} AD`;
+  assert.strictEqual(messedUp(data), expect);
+  assert.strictEqual(messedUp({}), '  , great  of Rome from  to  AD');
+  assert.strictEqual(
+    messedUp({ greeting: 'No way!' }),
+    'No way!  , great  of Rome from  to  AD',
+  );
+  assert.strictEqual(
+    messedUp({
+      greeting: 'Papa Roma is',
+      person: 'a',
+      positions: 'pizzeria',
+      ruleFrom: 1970,
+      ruleTo: 'today',
+    }),
+    'Papa Roma is a, great pizzeria of Rome from 1970 to today AD',
+  );
 }

--- a/test.js
+++ b/test.js
@@ -4,22 +4,65 @@ const assert = require('node:assert').strict;
 
 const t = require('./tickplate.js');
 
-const data = {
-  hello: 'Ave!',
-  myFriend: {
-    name: 'Marcus Aurelius',
-    toString() {
-      return this.name;
+{
+  ({ description: 'No fallbacks used.' });
+
+  const data = {
+    hello: 'Ave!',
+    myFriend: {
+      name: 'Marcus Aurelius',
+      toString() {
+        return this.name;
+      },
     },
-  },
-  positions: ['imperor', 'philosopher', 'writer'],
-};
+    positions: ['emperor', 'philosopher', 'writer'],
+  };
 
-const templ = t`${'hello'} ${'myFriend'}, great ${'positions'} of Rome`;
+  const templ = t`${'hello'} ${'myFriend'}, great ${'positions'} of Rome`;
 
-const expect = 'Ave! Marcus Aurelius, great imperor,philosopher,writer of Rome';
-const result = templ(data);
-assert.strictEqual(result, expect);
-assert.strictEqual(templ({ myFriend: 'Hadrian' }), ' Hadrian, great  of Rome');
-assert.strictEqual(templ({ hello: 'Hi!' }), 'Hi! , great  of Rome');
-assert.strictEqual(templ({}), ' , great  of Rome');
+  const expect =
+    'Ave! Marcus Aurelius, great emperor,philosopher,writer of Rome';
+  const result = templ(data);
+  assert.strictEqual(result, expect);
+  assert.strictEqual(
+    templ({ myFriend: 'Hadrian' }),
+    ' Hadrian, great  of Rome',
+  );
+  assert.strictEqual(templ({ hello: 'Hi!' }), 'Hi! , great  of Rome');
+  assert.strictEqual(templ({}), ' , great  of Rome');
+}
+
+{
+  ({
+    description:
+      'Fallback primitives and arrays of primitives provided, with "=" separator, empty spaces around trimmed',
+  });
+
+  const data = {
+    greeting: 'Ave!',
+    person: {
+      name: 'Lucius Verus',
+      toString() {
+        return this.name;
+      },
+    },
+    positions: ['brother', 'emperor', 'co-emperor'],
+    ruleFrom: 161,
+    ruleTo: 169,
+  };
+
+  const templ = t`${'greeting='} ${'person = "Marcus Aurelius"'}, great ${'positions  =["emperor", "philosopher"]'} of Rome from ${'ruleFrom = 161'} to ${'ruleTo=180'} AD`;
+
+  const expect =
+    'Ave! Lucius Verus, great brother,emperor,co-emperor of Rome from 161 to 169 AD';
+  const result = templ(data);
+  assert.strictEqual(result, expect);
+  assert.strictEqual(
+    templ({}),
+    ' Marcus Aurelius, great emperor,philosopher of Rome from 161 to 180 AD',
+  );
+  assert.strictEqual(
+    templ({ greeting: 'Valē!!!', ruleFrom: '44 BC', ruleTo: 2023 }),
+    'Valē!!! Marcus Aurelius, great emperor,philosopher of Rome from 44 BC to 2023 AD',
+  );
+}

--- a/test.js
+++ b/test.js
@@ -84,3 +84,13 @@ const t = require('./tickplate.js');
     'Papa Roma is a, great pizzeria of Rome from 1970 to today AD',
   );
 }
+
+{
+  ({ description: 'No fallbacks used, but values not passed either' });
+
+  const templ = t`${'hello='} ${'myFriend='}, great ${'positions='} of Rome`;
+  const expect = ' , great  of Rome';
+  const result = templ({});
+
+  assert.strictEqual(result, expect);
+}

--- a/tickplate.js
+++ b/tickplate.js
@@ -15,15 +15,26 @@ const parseKeyValuePair = (value, sep = SEPARATOR) => {
   }
 };
 
-const tickplate =
-  (strings, ...keys) =>
-  (values) => {
+const parseKeys = (strKeyValuePairs, sep = SEPARATOR) => {
+  const defaults = {};
+  for (const pair of strKeyValuePairs) {
+    const { key, value } = parseKeyValuePair(pair, sep);
+    defaults[key] = value;
+  }
+  return { keys: Object.keys(defaults), defaults };
+};
+
+const tickplate = (strings, ...keys) => {
+  const { keys: tickplateKeys, defaults } = parseKeys(keys);
+  return (values) => {
     const result = [strings[0]];
-    for (let i = 0; i < keys.length; i++) {
-      const { key, value: fallback } = parseKeyValuePair(keys[i]);
-      result.push(values[key] || fallback, strings[i + 1]);
+    for (let i = 0; i < tickplateKeys.length; i++) {
+      const key = tickplateKeys[i];
+      const value = key in values ? values[key] : defaults[key];
+      result.push(value, strings[i + 1]);
     }
     return result.join('');
   };
+};
 
 module.exports = tickplate;

--- a/tickplate.js
+++ b/tickplate.js
@@ -27,11 +27,11 @@ const parseKeys = (strKeyValuePairs, sep = SEPARATOR) => {
 const tickplate = (strings, ...keys) => {
   const { keys: tickplateKeys, defaults } = parseKeys(keys);
   return (values) => {
+    const tickplateValues = { ...defaults, ...values };
     const result = [strings[0]];
     for (let i = 0; i < tickplateKeys.length; i++) {
       const key = tickplateKeys[i];
-      const value = key in values ? values[key] : defaults[key];
-      result.push(value, strings[i + 1]);
+      result.push(tickplateValues[key], strings[i + 1]);
     }
     return result.join('');
   };

--- a/tickplate.js
+++ b/tickplate.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const metautil = require('metautil');
+
 const SEPARATOR = '=';
 
 const parseKeyValuePair = (value, sep = SEPARATOR) => {
@@ -7,12 +9,8 @@ const parseKeyValuePair = (value, sep = SEPARATOR) => {
   const key = lhs.trim();
   if (rhs.length === 0) return { key };
   const rhsRestored = rhs.join(sep).trim();
-  try {
-    const value = JSON.parse(rhsRestored);
-    return { key, value };
-  } catch {
-    return { key };
-  }
+  const value = metautil.jsonParse(rhsRestored);
+  return { key, value };
 };
 
 const parseKeys = (strKeyValuePairs, sep = SEPARATOR) => {

--- a/tickplate.js
+++ b/tickplate.js
@@ -9,8 +9,8 @@ const parseKeyValuePair = (value, sep = SEPARATOR) => {
   const key = lhs.trim();
   if (rhs.length === 0) return { key };
   const rhsRestored = rhs.join(sep).trim();
-  const value = metautil.jsonParse(rhsRestored);
-  return { key, value };
+  const parsed = metautil.jsonParse(rhsRestored);
+  return { key, value: parsed };
 };
 
 const parseKeys = (strKeyValuePairs, sep = SEPARATOR) => {

--- a/tickplate.js
+++ b/tickplate.js
@@ -1,12 +1,27 @@
 'use strict';
 
+const SEPARATOR = '=';
+
+const parseKeyValuePair = (value, sep = SEPARATOR) => {
+  const [lhs, ...rhs] = value.split(sep);
+  const key = lhs.trim();
+  if (rhs.length === 0) return { key };
+  const rhsRestored = rhs.join(sep).trim();
+  try {
+    const value = JSON.parse(rhsRestored);
+    return { key, value };
+  } catch {
+    return { key };
+  }
+};
+
 const tickplate =
   (strings, ...keys) =>
   (values) => {
     const result = [strings[0]];
     for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      result.push(values[key], strings[i + 1]);
+      const { key, value: fallback } = parseKeyValuePair(keys[i]);
+      result.push(values[key] || fallback, strings[i + 1]);
     }
     return result.join('');
   };


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings // N/A

Adding support for fallback values: primitives and arrays of primitives with tests covering numbers, strings, and arrays of strings.

NB! This is a remastered version of previously submtted PR. Though doing the same thing (enabling default values), does it in a slightly different and probably more efficient manner: parsing default values once on the tickplate init stage, rather than each time the template is being used. If all the ticklates needed for the application are instantiated at app start-up time and them re-used with new and new data coming in (which I suppose they are), this implemention will be more performant.
